### PR TITLE
Added props-doc to the TableOfRecords example

### DIFF
--- a/src-docs/src/components/guide_section/guide_section.js
+++ b/src-docs/src/components/guide_section/guide_section.js
@@ -22,6 +22,7 @@ import {
   EuiText,
   EuiTextColor,
   EuiTitle,
+  EuiLink
 } from '../../../../src/components';
 
 
@@ -139,7 +140,7 @@ export class GuideSection extends Component {
     }
 
     const docgenInfo = Array.isArray(component.__docgenInfo) ? component.__docgenInfo[0] : component.__docgenInfo;
-    const { description, props } = docgenInfo;
+    const { _euiObjectType, description, props } = docgenInfo;
 
     if (!props && !description) {
       return;
@@ -169,6 +170,22 @@ export class GuideSection extends Component {
 
       const humanizedType = humanizeType(type);
 
+      function markup(text) {
+        const regex = /(#[a-zA-Z]+)/;
+        return text.split(regex).map(token => {
+          if (!token.startsWith('#')) {
+            return token;
+          }
+          const id = token.substring(1);
+          const onClick = () => {
+            document.getElementById(id).scrollIntoView();
+          };
+          return <EuiLink onClick={onClick}>{id}</EuiLink>;
+        });
+      }
+
+      const typeMarkup = markup(humanizedType);
+
       const cells = [
         (
           <EuiTableRowCell key="name">
@@ -176,7 +193,7 @@ export class GuideSection extends Component {
           </EuiTableRowCell>
         ), (
           <EuiTableRowCell key="type">
-            <EuiCode>{humanizedType}</EuiCode>
+            <EuiCode>{typeMarkup}</EuiCode>
           </EuiTableRowCell>
         ), (
           <EuiTableRowCell key="defaultValue">
@@ -195,6 +212,10 @@ export class GuideSection extends Component {
         </EuiTableRow>
       );
     });
+
+    const title = _euiObjectType === 'type' ?
+      <EuiCode id={componentName}>{componentName}</EuiCode> :
+      <EuiText color="accent">{componentName}</EuiText>;
 
     let descriptionElement;
 
@@ -241,7 +262,7 @@ export class GuideSection extends Component {
 
     return [
       <EuiSpacer size="m" key={`propsSpacer-${componentName}-1`} />,
-      <EuiTitle size="s" key={`propsName-${componentName}`}><h3>Props for {componentName}</h3></EuiTitle>,
+      <EuiTitle size="s" key={`propsName-${componentName}`}><h3>{title}</h3></EuiTitle>,
       <EuiSpacer size="s" key={`propsSpacer-${componentName}-2`} />,
       descriptionElement,
       table,

--- a/src-docs/src/views/table_of_records/propsInfo.js
+++ b/src-docs/src/views/table_of_records/propsInfo.js
@@ -1,0 +1,423 @@
+export const propsInfo = {
+
+  EuiTableOfRecords: {
+    __docgenInfo: {
+      props: {
+        config: {
+          description: 'Configures the features and behaviour of the table',
+          required: true,
+          type: { name: '#Config' }
+        },
+        model: {
+          description: 'Defines the data model of this table',
+          required: true,
+          type: { name: '#Model' }
+        }
+      }
+    }
+  },
+
+  Model: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        data: {
+          description: 'Holds the data for the table',
+          required: true,
+          type: { name: '#ModelData' }
+        },
+        criteria: {
+          description: 'Defines the criteria to which the data adheres',
+          required: false,
+          type: { name: '#ModelCriteria' }
+        }
+      }
+    }
+  },
+
+
+  ModelData: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        records: {
+          description: 'An array of the records to be displayed',
+          required: true,
+          type: { name: 'object[]' }
+        },
+        totalRecordCount: {
+          description: 'The total number of records that match the criteria',
+          required: false,
+          type: { name: 'number' }
+        }
+      }
+    }
+  },
+
+  ModelCriteria: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        page: {
+          description: 'If the data records represents a page into a bigger set, this describes this page',
+          required: false,
+          type: { name: '#ModelCriteriaPage' }
+        },
+        sort: {
+          description: 'If the data records are sorted, this describes the sort criteria',
+          required: false,
+          type: { name: '#ModelCriteriaSort' }
+        }
+      }
+    }
+  },
+
+  ModelCriteriaPage: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        size: {
+          description: 'The maximum number of records per page',
+          required: true,
+          type: { name: 'number' }
+        },
+        index: {
+          description: 'The page (zero-based) index',
+          required: false,
+          type: { name: 'number' }
+        }
+      }
+    }
+  },
+
+  ModelCriteriaSort: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        field: {
+          description: 'The field the data is sorted on',
+          required: true,
+          type: { name: 'string' }
+        },
+        direction: {
+          description: 'The direction of the sort',
+          required: false,
+          type: { name: '"asc" | "desc"' }
+        }
+      }
+    }
+  },
+
+  Config: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        columns: {
+          description: 'Defines the table columns',
+          required: true,
+          defaultValue: undefined,
+          type: { name: '(#FieldDataColumn | #ComputedColumn | #ActionsColumn)[]' }
+        },
+        onDataCriteriaChange: {
+          description: 'A callback to handle changes in the data criteria',
+          required: false,
+          type: { name: '(criteria: #ModelCriteria) => void' }
+        },
+        selection: {
+          description: 'Configuring selection',
+          required: false,
+          type: { name: '#ConfigSelection' }
+        },
+        pagination: {
+          description: 'Configuring pagination',
+          required: false,
+          type: { name: '#ConfigPagination' }
+        }
+      }
+    }
+  },
+
+  ConfigSelection: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        onSelectionChanged: {
+          description: 'A callback that will be called whenever the record selection changes',
+          required: false,
+          type: { name: '(selectedRecords) => void' }
+        },
+        selectable: {
+          description: 'A callback that is called per record to indicate whether it is selectable',
+          required: false,
+          type: { name: '(record, model) => void' }
+        }
+      }
+    }
+  },
+
+  ConfigPagination: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      props: {
+        pageSizeOptions: {
+          description: 'Configures the page size dropdown options',
+          required: false,
+          defaultValue: '[5, 10, 20]',
+          type: { name: 'number[]' }
+        }
+      }
+    }
+  },
+
+  FieldDataColumn: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      description: `Describes a column that displays a value derived of one of the Record's fields`,
+      props: {
+        field: {
+          description: 'A field of the record (may be a nested field)',
+          required: true,
+          type: { name: 'string' }
+        },
+        name: {
+          description: 'The display name of the column',
+          required: true,
+          type: { name: 'string' }
+        },
+        description: {
+          description: 'A description of the column (will be presented as a title over the column header',
+          required: false,
+          type: { name: 'string' }
+        },
+        dataType: {
+          description: 'Describes the data types of the displayed value (serves as a rendering hint for the table)',
+          required: false,
+          type: { name: '"string" | "number" | "date" | "boolean"' }
+        },
+        width: {
+          description: 'A CSS width property. Hints for the required width of the column',
+          required: false,
+          type: { name: 'string (e.g. "30%", "100px", etc..)' }
+        },
+        sortable: {
+          description: 'Defines whether the user can sort on this column',
+          required: false,
+          defaultValue: 'false',
+          type: { name: 'boolean' }
+        },
+        align: {
+          description: 'Defines the horizontal alignment of the column',
+          required: false,
+          defaultValue: 'right (though may change when "dataType" is defined',
+          type: { name: '"left" | "right"' }
+        },
+        truncateText: {
+          description: `Indicates whether this column should truncate its content when it doesn't fit`,
+          required: false,
+          defaultValue: 'false',
+          type: { name: 'boolean' }
+        },
+        render: {
+          description: `Describe a custom renderer function for the content`,
+          required: false,
+          type: { name: '(value, record) => PropTypes.node' }
+        }
+      }
+    }
+  },
+
+  ComputedColumn: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      description: `Describes a column for computed values`,
+      props: {
+        render: {
+          description: `A function that computes the value for each record and renders it`,
+          required: true,
+          type: { name: '(value, record) => PropTypes.node' }
+        },
+        name: {
+          description: 'The display name of the column',
+          required: false,
+          type: { name: 'string' }
+        },
+        description: {
+          description: 'A description of the column (will be presented as a title over the column header',
+          required: false,
+          type: { name: 'string' }
+        },
+        width: {
+          description: 'A CSS width property. Hints for the required width of the column',
+          required: false,
+          type: { name: 'string (e.g. "30%", "100px", etc..)' }
+        },
+        truncateText: {
+          description: `Indicates whether this column should truncate its content when it doesn't fit`,
+          required: false,
+          defaultValue: 'false',
+          type: { name: 'boolean' }
+        }
+      }
+    }
+  },
+
+  ActionsColumn: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      description: `Describes a column that holds action controls (e.g. Buttons)`,
+      props: {
+        actions: {
+          description: `An array of actions to associate per record`,
+          required: true,
+          type: { name: '(#ButtonRecordAction | #IconRecordAction | #CustomRecordAction)[]' }
+        },
+        name: {
+          description: 'The display name of the column',
+          required: false,
+          type: { name: 'string' }
+        },
+        description: {
+          description: 'A description of the column (will be presented as a title over the column header',
+          required: false,
+          type: { name: 'string' }
+        },
+        width: {
+          description: 'A CSS width property. Hints for the required width of the column',
+          required: false,
+          type: { name: 'string (e.g. "30%", "100px", etc..)' }
+        }
+      }
+    }
+  },
+
+  ButtonRecordAction: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      description: `Describes an action that is displayed as a button`,
+      props: {
+        type: {
+          description: 'The type of action - must be set to "button"',
+          required: true,
+          type: { name: 'string (must be "button")' }
+        },
+        name: {
+          description: 'The display name of the action (will be the button caption',
+          required: true,
+          type: { name: 'string' }
+        },
+        description: {
+          description: 'Describes the action (will be the button title)',
+          required: true,
+          type: { name: 'string' }
+        },
+        onClick: {
+          description: 'A handler function to execute the action',
+          required: true,
+          type: { name: '(record, model) => void' }
+        },
+        visible: {
+          description: 'A callback function that determines whether the action is visible',
+          required: false,
+          defaultValue: '() => true',
+          type: { name: '(record, model) => boolean' }
+        },
+        enabled: {
+          description: 'A callback function that determines whether the action is enabled',
+          required: false,
+          defaultValue: '() => true',
+          type: { name: '(record, model) => boolean' }
+        },
+        icon: {
+          description: 'Associates an icon with the button',
+          required: false,
+          type: { name: 'string (must be one of the supported icon types)' }
+        },
+        color: {
+          description: 'Defines the color of the button',
+          required: false,
+          type: { name: 'string (must be one of the supported button colors)' }
+        }
+      }
+    }
+  },
+
+  IconRecordAction: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      description: `Describes an action that is displayed as an icon`,
+      props: {
+        type: {
+          description: 'The type of action - must be set to "icon"',
+          required: true,
+          type: { name: 'string (must be "icon")' }
+        },
+        name: {
+          description: 'The display name of the action',
+          required: true,
+          type: { name: 'string' }
+        },
+        description: {
+          description: 'Describes the action (will be the button title)',
+          required: true,
+          type: { name: 'string' }
+        },
+        onClick: {
+          description: 'A handler function to execute the action',
+          required: true,
+          type: { name: '(record, model) => void' }
+        },
+        visible: {
+          description: 'A callback function that determines whether the action is visible',
+          required: false,
+          defaultValue: '() => true',
+          type: { name: '(record, model) => boolean' }
+        },
+        enabled: {
+          description: 'A callback function that determines whether the action is enabled',
+          required: false,
+          defaultValue: '() => true',
+          type: { name: '(record, model) => boolean' }
+        },
+        icon: {
+          description: 'The icon that should be shown',
+          required: true,
+          type: { name: 'string (must be one of the supported icon types)' }
+        },
+        color: {
+          description: 'Defines the color of the icon',
+          required: false,
+          type: { name: 'string (must be one of the supported button colors)' }
+        }
+      }
+    }
+  },
+
+  CustomRecordAction: {
+    __docgenInfo: {
+      _euiObjectType: 'type',
+      description: `Describes a custom action`,
+      props: {
+        type: {
+          description: 'The type of action - must be set to "custom"',
+          required: true,
+          type: { name: 'string (must be "custom")' }
+        },
+        render: {
+          description: 'The function that renders the action',
+          required: true,
+          type: { name: '(record, model, enabled) => PropTypes.node' }
+        },
+        visible: {
+          description: 'A callback that defines whether the action is visible',
+          required: false,
+          type: { name: '(record, model) => boolean' }
+        },
+        enabled: {
+          description: 'A callback that defines whether the action is enabled',
+          required: false,
+          type: { name: '(record, model) => boolean' }
+        }
+      }
+    }
+  },
+};

--- a/src-docs/src/views/table_of_records/table_of_records_example.js
+++ b/src-docs/src/views/table_of_records/table_of_records_example.js
@@ -19,6 +19,7 @@ const implicitRecordActionSource = require('!!raw-loader!./implicit_record_actio
 const implicitRecordActionHtml = renderToHtml(ImplicitRecordActionsTable);
 
 import ColumnDataTypes from './column_data_types';
+import { propsInfo } from './propsInfo';
 const columnRenderersSource = require('!!raw-loader!./column_data_types');
 const columnRenderersHtml = renderToHtml(ColumnDataTypes);
 
@@ -112,6 +113,7 @@ export const TableOfRecordsExample = {
           </ul>
         </div>
       ),
+      props: propsInfo,
       demo: <MultipleRecordActionsTable />
     },
     {

--- a/src/components/table_of_records/table_of_records.js
+++ b/src/components/table_of_records/table_of_records.js
@@ -64,7 +64,7 @@ const IconRecordActionType = PropTypes.shape({
   onClick: PropTypes.func.isRequired, // (record, model) => void,
   visible: PropTypes.func, // (record, model) => boolean;
   enabled: PropTypes.func, // (record, model) => boolean;
-  icon: PropTypes.oneOf(ICON_TYPES),
+  icon: PropTypes.oneOf(ICON_TYPES).isRequired,
   color: PropTypes.oneOfType([
     PropTypes.oneOf(BUTTON_ICON_COLORS),
     PropTypes.func // (record, model) => oneOf(ICON_BUTTON_COLORS)


### PR DESCRIPTION
- since the default props docs don't support rich props hierarchy, we construct the docgen info ourselves.
- changes the styling of the props docs
- introduced a special `_euiObjectType` field in docgenInfo "mark" the documented component as a "type" rather than a react component
- added internal links between the different types